### PR TITLE
結果表示のリセット機能を追加

### DIFF
--- a/app7.py
+++ b/app7.py
@@ -37,6 +37,7 @@ if st.sidebar.button("アンケートをリセット"):
     st.session_state.fashion_sensitivity = None
     st.session_state.fashion_purchase_frequency = None
     st.session_state.budget = None
+    st.session_state.show_results = None # ← 右側の結果もリセットするために加えました
     st.sidebar.write("アンケートがリセットされました")
 
 # サイドバーに名前を入力


### PR DESCRIPTION
「アンケートをリセット」ボタンを押すと、アンケートに加えて右側の結果の表示もリセットされるようにコードを一行加えました。プルリク承認、おなしゃす！